### PR TITLE
[refs #1264] fix the problem in put_metric_bolt.py

### DIFF
--- a/synaps-storm/multilang/resources/put_metric_bolt.py
+++ b/synaps-storm/multilang/resources/put_metric_bolt.py
@@ -530,9 +530,14 @@ class PutMetricBolt(storm.BasicBolt):
         alarm_name = message.get('alarm_name')
         state_reason_data = message.get('state_reason_data')
         alarm_key = self.cass.get_metric_alarm_key(project_id, alarm_name)
+        
+        if metric_key not in self.metrics:
+            self.metrics[metric_key] = MetricMonitor(metric_key, self.cass)
 
         metric = self.metrics[metric_key]
+        
         metricalarm = metric.alarms[alarm_key]
+                
         metricalarm['state_reason'] = message.get('state_reason')
         metricalarm['state_value'] = message.get('state_value')
         metricalarm['state_reason_data'] = message.get('state_reason_data')


### PR DESCRIPTION
2012-10-18 16:01:03 ShellBolt [INFO] Shell msg: [PutMetricBolt] process set_alarm_state_msg ({u'state_reason': u'Manual input', u'alarm_name': u'TEST_ALARM_00', u'project_id': u'IaaS', u'state_reason_data': None, u'message_id': 6, u'state_value': u'ALARM'})
2012-10-18 16:01:03 ShellBolt [INFO] Shell msg: [PutMetricBolt] TRACE: Traceback (most recent call last):
2012-10-18 16:01:03 ShellBolt [INFO] Shell msg: [PutMetricBolt] TRACE:   File "put_metric_bolt.py", line 586, in process
2012-10-18 16:01:03 ShellBolt [INFO] Shell msg: [PutMetricBolt] TRACE:     self.process_set_alarm_state_msg(metric_key, message)
2012-10-18 16:01:03 ShellBolt [INFO] Shell msg: [PutMetricBolt] TRACE:   File "put_metric_bolt.py", line 542, in process_set_alarm_state_msg
2012-10-18 16:01:03 ShellBolt [INFO] Shell msg: [PutMetricBolt] TRACE:     metric = self.metrics[metric_key]
2012-10-18 16:01:03 ShellBolt [INFO] Shell msg: [PutMetricBolt] TRACE: KeyError: UUID('1d259bcc-fb41-49c2-87bd-624d95d81b07')
2012-10-18 16:01:03 task [INFO] Emitting: putmetric_bolt __ack_fail [366708141450416400]
2012-10-18 16:01:03 executor [INFO] Processing received message source: unpack_bolt:29, stream: default, id: {-252866514438936138=-4037304698420445617}, [9f178fb5-53aa-4311-8f79-cb5ffa15a1af, {"metric_name": "DiskWriteBytes", "timestamp": "2012-10-18T07:00:55.605058", "namespace": "SPCS/NOVA", "value": 0, "project_id": "P20121018-001", "message_id": 1, "unit": "Bytes/Second", "dimensions": {"instanceId": "instance-000015e5"}}]
2012-10-18 16:01:03 util [ERROR] Async loop died!
java.lang.RuntimeException: java.lang.RuntimeException: java.lang.RuntimeException: Acked a non-existent or already acked/failed id: 682649859169323720
    at backtype.storm.utils.DisruptorQueue.consumeBatchToCursor(DisruptorQueue.java:82)

Problem reason :
Synaps can't find metric key in cassandra when work set_alarm_state.
so I attatched that code, and it works without dead.
