### PR TITLE
[refs #1265] fix the problem in action_bolt and put_metric_bolt

### DIFF
--- a/synaps-storm/multilang/resources/action_bolt.py
+++ b/synaps-storm/multilang/resources/action_bolt.py
@@ -119,7 +119,15 @@ class ActionBolt(storm.BasicBolt):
         self.log("message received: %s " % message_buf)
         
         alarm = self.cass.get_metric_alarm(UUID(alarm_key))
-        actions_enabled = alarm['actions_enabled']
+        
+        try:        
+            actions_enabled = alarm['actions_enabled']
+        except TypeError:
+            msg = "alarm is not found [" + alarm_key + "]"
+            self.log(msg)
+            
+            return False
+                     
         if message['state'] == 'OK':
             actions = json.loads(alarm['ok_actions'])
         elif message['state'] == 'INSUFFICIENT_DATA':

--- a/synaps-storm/multilang/resources/put_metric_bolt.py
+++ b/synaps-storm/multilang/resources/put_metric_bolt.py
@@ -185,11 +185,14 @@ class MetricMonitor(object):
         alarm_name = metricalarm.get('alarm_name')
         alarm_key = self.cass.get_metric_alarm_key(project_id, alarm_name)
         if alarm_key:
-            self.alarms[alarm_key] = self.cass.get_metric_alarm(alarm_key)
-            storm.log("alarm key is [%s]" % alarm_key)
+            ret = self.cass.get_metric_alarm(alarm_key)
+            if ret:
+                self.alarms[alarm_key] = ret
+                storm.log("alarm key is [%s]" % alarm_key)
+            else:
+                storm.log("alarm key [%s] is found, but alarm is not found." % alarm_key)
         else:
             storm.log("no alarm key [%s]" % alarm_key)
-            
 
         self.set_max_start_period(self.alarms)
         

--- a/synaps-storm/multilang/resources/put_metric_bolt.py
+++ b/synaps-storm/multilang/resources/put_metric_bolt.py
@@ -107,12 +107,18 @@ class MetricMonitor(object):
     def set_max_start_period(self, alarms):
         msp = self.MAX_START_PERIOD
         
-        self.MAX_START_PERIOD = max(v.get('period') for v 
-                                    in alarms.itervalues()) \
-                                if alarms else FLAGS.get('max_start_period') 
-        self.MIN_START_PERIOD = min(v.get('period') for v 
-                                    in alarms.itervalues()) \
-                                if alarms else 0
+        try:
+            self.MAX_START_PERIOD = max(v.get('period') for v 
+                                        in alarms.itervalues()) \
+                                    if alarms else FLAGS.get('max_start_period') 
+            self.MIN_START_PERIOD = min(v.get('period') for v 
+                                        in alarms.itervalues()) \
+                                    if alarms else 0
+        except AttributeError:
+            msg = "alarm is not found in alarms."
+            self.log(msg)
+            
+            return False 
                   
         msg = "MAX_START_PERIOD is changed %s -> %s"                 
         storm.log(msg % (str(msp), self.MAX_START_PERIOD))


### PR DESCRIPTION
[refs #1265] fix the problem in action_bolt

2012-10-18 16:14:17 ShellBolt [INFO] Shell msg: [ActionBolt] message received: {"body": "Threshold Crossed: 3 datapoints were not greater than the threshold(50.000000). The most recent datapoints: [19.063736883008605, 19.939493217786275, 19.939493217786275]. at 2012-10-18T07:14:17.432259", "state": "OK", "query_date": "2012-10-18T07:14:17.432259", "subject": "Test_Alarm_Period state has been changed from INSUFFICIENT_DATA to OK at 2012-10-18T07:14:17.432259"} 
2012-10-18 16:14:17 ShellBolt [INFO] Shell msg: [ActionBolt] TRACE: Traceback (most recent call last):
2012-10-18 16:14:17 ShellBolt [INFO] Shell msg: [ActionBolt] TRACE:   File "action_bolt.py", line 166, in process
2012-10-18 16:14:17 ShellBolt [INFO] Shell msg: [ActionBolt] TRACE:     self.process_action(tup)
2012-10-18 16:14:17 ShellBolt [INFO] Shell msg: [ActionBolt] TRACE:   File "action_bolt.py", line 122, in process_action
2012-10-18 16:14:17 ShellBolt [INFO] Shell msg: [ActionBolt] TRACE:     actions_enabled = alarm['actions_enabled']
2012-10-18 16:14:17 ShellBolt [INFO] Shell msg: [ActionBolt] TRACE: TypeError: 'NoneType' object has no attribute '**getitem**'
2012-10-18 16:14:17 task [INFO] Emitting: action_bolt __ack_fail [-1482895226000877327]

sometimes worker was dead in stress test.
I expect the reason was put_alarm method. I modified codes and it will avoid worker's dead.
