### PR TITLE
Return unit from GetMetricStatistics if unset in request

### DIFF
--- a/synaps-api/synaps/api/cloudwatch/monitor.py
+++ b/synaps-api/synaps/api/cloudwatch/monitor.py
@@ -251,7 +251,7 @@ class MonitorController(object):
                     ret['Unit'] = "Count"
                     ret[statistic] = value
                 else:
-                    ret['Unit'] = unit
+                    ret['Unit'] = (unit if unit != 'None' else None)
                     ret[statistic] = utils.to_unit(value, unit)
                     
             return ret
@@ -270,7 +270,8 @@ class MonitorController(object):
         self.check_unit(unit)
         self.check_period(period)
         
-        stats = self.monitor_api.get_metric_statistics(project_id, end_time,
+        stats, unit = self.monitor_api.get_metric_statistics(
+                                                       project_id, end_time,
                                                        metric_name, namespace,
                                                        period, start_time,
                                                        statistics, unit,

--- a/synaps-api/synaps/monitor/api.py
+++ b/synaps-api/synaps/monitor/api.py
@@ -181,7 +181,7 @@ class API(object):
             stat[statistic] = func(ts, period, min_periods=0)
 
         ret = filter(None, (to_datapoint(stat, i) for i in stat.index))
-        return ret
+        return ret, unit
 
     def list_metrics(self, project_id, next_token=None, dimensions=None,
                      metric_name=None, namespace=None):

--- a/synaps-api/synaps/tests/test_cloudwatch.py
+++ b/synaps-api/synaps/tests/test_cloudwatch.py
@@ -462,6 +462,11 @@ class ShortCase(SynapsTestCase):
         #expected = stat1['Sum'] + test_value
         self.assertAlmostEqual(stat1['Sum'] + test_value, stat2['Sum'])
         
+        # expect that the unit matches that specified on the corresponding
+        # PutMetricData call, even though we do not explicitly state the
+        # in the GetMetricStatistics call
+        self.assertEqual(stat2['Unit'], "Percent")
+
         # check 400 error when period is invalid
         test_period = 50
         try:


### PR DESCRIPTION
Fixes bug 1076432

Previously the unit would not be provided in the GetMetricStatistics
response if not explicitly specified in the corresponding request.

Now the unit from the metric store is returned in this case.
