### PR TITLE
Avoid reporting zero sample counts for sparse metrics

### DIFF
--- a/synaps-api/synaps/api/cloudwatch/monitor.py
+++ b/synaps-api/synaps/api/cloudwatch/monitor.py
@@ -256,6 +256,12 @@ class MonitorController(object):
                     
             return ret
 
+        def non_null(stat):
+            for statistic, value in stat[1].iteritems():
+                 if not (statistic == 'SampleCount' and value == 0.0):
+                     return True
+            return False
+
         if not (project_id and context.is_admin):
             project_id = context.project_id
         end_time = utils.parse_strtime(end_time)
@@ -277,7 +283,7 @@ class MonitorController(object):
                                                        statistics, unit,
                                                        dimensions)
     
-        datapoints = map(stat_to_datapoint, stats)
+        datapoints = map(stat_to_datapoint, filter(non_null, stats))
         label = metric_name
         
         return {'GetMetricStatisticsResult': {'Datapoints': datapoints,

--- a/synaps-api/synaps/tests/test_cloudwatch.py
+++ b/synaps-api/synaps/tests/test_cloudwatch.py
@@ -337,6 +337,22 @@ class ShortCase(SynapsTestCase):
         
         self.assertAlmostEqual(stat1['SampleCount'], stat2['SampleCount'])
         
+        # Ensure zero sample counts are not reported for periods without
+        # actual datapoints
+
+        way_before_start = start_time - datetime.timedelta(weeks=20*52) 
+        way_before_end = way_before_start + datetime.timedelta(hours=1)
+
+        ancient_stat = self.synaps.get_metric_statistics(
+            period=300, start_time=way_before_start, end_time=way_before_end,
+            metric_name="SampleCountTest", namespace=self.namespace,
+            statistics=['SampleCount'],
+            unit="Bytes",
+            dimensions=self.dimensions,
+        )
+
+        self.assertEqual(len(ancient_stat), 0)
+
     def test_alarm_period(self):
         
         #알람을 생성, MAX_START_PERIOD 를 6000 으로 증가시키는지 테스트.


### PR DESCRIPTION
Fixes bug 1077042

Previously for sparse metrics (i.e. where there exist only relatively
few actual datapoints), the responses to calls on the GetMetricStatistics
API seeking the SampleCount statistic were polluted with many trivial
datapoints for the periods in which there were no metrics reported.

Now these meaningless & unnecessary data are excised from the response,
as they may be inferred.
